### PR TITLE
Fix JSON after recent Luau changes

### DIFF
--- a/Interpreter.agda
+++ b/Interpreter.agda
@@ -16,7 +16,7 @@ open import FFI.System.Exit using (exitWith; ExitFailure)
 
 open import Luau.StrictMode.ToString using (warningToStringᴮ)
 open import Luau.Syntax using (Block; yes; maybe; isAnnotatedᴮ)
-open import Luau.Syntax.FromJSON using (blockFromJSON)
+open import Luau.Syntax.FromJSON using (programFromJSON)
 open import Luau.Syntax.ToString using (blockToString; valueToString)
 open import Luau.Run using (run; return; done; error)
 open import Luau.RuntimeError.ToString using (errToStringᴮ)
@@ -37,7 +37,7 @@ runBlock B | nothing = putStrLn ("UNANNOTATED PROGRAM:\n" ++ blockToString B) >>
 runBlock B | just B′ = putStrLn ("ANNOTATED PROGRAM:\n" ++ blockToString B) >> runBlock′ yes B′
 
 runJSON : Value → IO ⊤
-runJSON value with blockFromJSON(value)
+runJSON value with programFromJSON(value)
 runJSON value | (Left err) = putStrLn ("LUAU ERROR: " ++ err) >> exitWith (ExitFailure (pos 1))
 runJSON value | (Right block) = runBlock block
 

--- a/Luau/Syntax/FromJSON.agda
+++ b/Luau/Syntax/FromJSON.agda
@@ -22,6 +22,7 @@ lokal = fromString "local"
 list = fromString "list"
 name = fromString "name"
 type = fromString "type"
+luauType = fromString "luauType"
 value = fromString "value"
 values = fromString "values"
 vars = fromString "vars"
@@ -30,6 +31,7 @@ left = fromString "left"
 right = fromString "right"
 returnAnnotation = fromString "returnAnnotation"
 types = fromString "types"
+root = fromString "root"
 
 data Lookup : Set where
   _,_ : String → Value → Lookup
@@ -51,6 +53,7 @@ statFromJSON : Value → Either String (Stat maybe)
 statFromObject : Object → Either String (Stat maybe)
 blockFromJSON : Value → Either String (Block maybe)
 blockFromArray : Array → Either String (Block maybe)
+programFromJSON : Value → Either String (Block maybe)
 
 binOpFromJSON (string s) = binOpFromString s
 binOpFromJSON _ = Left "Binary operator not a string"
@@ -71,7 +74,7 @@ binOpFromString s = Left ("'" ++ s ++ "' is not a valid operator")
 varDecFromJSON (object arg) = varDecFromObject arg
 varDecFromJSON _ = Left "VarDec not an object"
 
-varDecFromObject obj with lookup name obj | lookup type obj
+varDecFromObject obj with lookup name obj | lookup luauType obj
 varDecFromObject obj | just (string name) | nothing = Right (var name)
 varDecFromObject obj | just (string name) | just Value.null = Right (var name)
 varDecFromObject obj | just (string name) | just tyValue with typeFromJSON tyValue
@@ -199,3 +202,7 @@ blockFromArray arr | just value | Right S with blockFromArray(tail arr)
 blockFromArray arr | just value | Right S | Left err = Left (err)
 blockFromArray arr | just value | Right S | Right B  = Right (S ∙ B)
    
+programFromJSON (object obj) with lookup root obj
+programFromJSON obj | just block = blockFromJSON block
+programFromJSON (object obj) | nothing = Left "missing root"
+programFromJSON _ = Left "not an object"

--- a/PrettyPrinter.agda
+++ b/PrettyPrinter.agda
@@ -14,14 +14,14 @@ open import FFI.Data.Text.Encoding using (encodeUtf8)
 open import FFI.System.Exit using (exitWith; ExitFailure)
 
 open import Luau.Syntax using (Block)
-open import Luau.Syntax.FromJSON using (blockFromJSON)
+open import Luau.Syntax.FromJSON using (programFromJSON)
 open import Luau.Syntax.ToString using (blockToString)
 
 runBlock : ∀ {a} → Block a → IO ⊤
 runBlock block = putStrLn (blockToString block)
 
 runJSON : Value → IO ⊤
-runJSON value with blockFromJSON(value)
+runJSON value with programFromJSON(value)
 runJSON value | (Left err) = putStrLn ("Luau error: " ++ err) >> exitWith (ExitFailure (pos 1))
 runJSON value | (Right block) = runBlock block
 


### PR DESCRIPTION
JSON input now has "root" in the root object that corresponds to the
AST, and "type" now consistently refers to the AST type, with luauType
used for the actual type annotations.